### PR TITLE
bugfix: se arreglo error al querer actualizar sala

### DIFF
--- a/api/internal/rooms/application/useCases/updateUsecase.go
+++ b/api/internal/rooms/application/useCases/updateUsecase.go
@@ -19,6 +19,7 @@ func NewUpdateRoomUsecase(repository domain.RoomRepository) *UpdateRoomUsecase {
 
 func (u *UpdateRoomUsecase) Execute(room *domain.Room, userID sv.ID) (*domain.Room, error) {
 	// Buscar la sala por ID
+
 	existingRoom, err := u.repository.GetByID(room.ID())
 	if err != nil {
 		return nil, err
@@ -26,6 +27,11 @@ func (u *UpdateRoomUsecase) Execute(room *domain.Room, userID sv.ID) (*domain.Ro
 	if existingRoom == nil {
 		return nil, e.ErrRoomNotFound
 	}
+
+	//solo la puede editar si la sala no inicio
+	if existingRoom.State().CurrentState !=  "created" {
+		return nil, e.ErrStateConstraint
+	} 
 
 	if existingRoom.AdminID() != userID {
 		return nil, errors.New("unauthorized")

--- a/api/internal/rooms/application/useCases/websocket/socketStructs/Event.go
+++ b/api/internal/rooms/application/useCases/websocket/socketStructs/Event.go
@@ -16,6 +16,9 @@ const (
 	EventEndVoting = "end_voting"
 	EventVote = "vote"
 	EventResults = "results"
+	EventFirstProp = "first_proposal"
+	EventNextProp = "next_proposal"
+	EventError = "error"
 )
 
 type SendMessageEvent struct {
@@ -27,3 +30,14 @@ type UpdateClientListEvent struct {
 	Clients []string `json:"clients"`
 }
 
+type ErrorEvent struct{
+	Message string `json:"message"`
+}
+
+type FirstPropEvent struct {
+	Prop string `json:"prop"`
+}
+
+type NextPropEvent struct {
+	Prop string `json:"prop"`
+}

--- a/api/internal/rooms/domain/errors/stateConstraint.go
+++ b/api/internal/rooms/domain/errors/stateConstraint.go
@@ -1,0 +1,9 @@
+package errors
+
+type roomStateConstraint string
+
+const ErrStateConstraint roomStateConstraint = "the current room state doesnt support this operation."
+
+func (r roomStateConstraint) Error() string {
+	return string(r)
+}

--- a/api/internal/rooms/infrastructure/roomEchoHandler.go
+++ b/api/internal/rooms/infrastructure/roomEchoHandler.go
@@ -578,6 +578,8 @@ func (h *RoomEchoHandler) Update(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid room isFormal"})
 	}
 
+	state, err := v.NewState("created")
+	
 	room := d.NewRoom(
 		id,
 		*linkInvite,
@@ -585,7 +587,7 @@ func (h *RoomEchoHandler) Update(c echo.Context) error {
 		*name,
 		adminID,
 		*description,
-		nil,
+		state,
 	)
 
 	userID, err := GetUserIDFromSession(c)
@@ -598,6 +600,10 @@ func (h *RoomEchoHandler) Update(c echo.Context) error {
 	if err != nil {
 		if err.Error() == "unauthorized" {
 			return c.JSON(http.StatusMethodNotAllowed, map[string]string{"error": err.Error()})
+		}
+
+		if errors.Is(rerr.ErrStateConstraint, err) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}

--- a/api/internal/shared/infrastructure/echoServer.go
+++ b/api/internal/shared/infrastructure/echoServer.go
@@ -105,7 +105,7 @@ func (s *EchoServer) Start() {
 	deps := NewDependencies(s.db)
 
 	s.InitializeUser(deps.UserRepo)
-	s.InitializeRoom(deps.UserRepo, deps.SettingRoomRepo)
+	s.InitializeRoom(deps.UserRepo, deps.SettingRoomRepo, deps.ProposalRepo)
 	s.InitializeSettingRoom(deps.SettingRoomRepo, deps.RoomRepo)
 	s.InitializeProposal(deps.ProposalRepo, deps.RoomRepo)
 	s.InitializeVote()
@@ -191,7 +191,7 @@ func (s *EchoServer) InitializeVote() {
 	v.InitializeVoteEchoRouter(s.app, voteHandler)
 }
 
-func (s *EchoServer) InitializeRoom(userRepo userDom.UserRepository, settingRoomRepo srDom.SettingRoomRepository) {
+func (s *EchoServer) InitializeRoom(userRepo userDom.UserRepository, settingRoomRepo srDom.SettingRoomRepository, proposalRepo propDom.ProposalRepository) {
 	roomRepo := r.NewRoomXormRepository(s.db)
 	createRoomUseCase := roomUsecase.NewCreateUsecase(roomRepo)
 	deleteRoomUseCase := roomUsecase.NewDeleteUsecase(roomRepo)
@@ -202,7 +202,7 @@ func (s *EchoServer) InitializeRoom(userRepo userDom.UserRepository, settingRoom
 	joinUsecase := roomUsecase.NewJoinRoomUsecase(roomRepo)
 	AddSingleUserUsecase := roomUsecaseAddUsers.NewAddSingleUserUsecase(roomRepo, userRepo)
 	UpdateRoomUseCase := roomUsecase.NewUpdateRoomUsecase(roomRepo)
-	ManageWsUsecase := roomWsUsecase.NewManageWsUsecase(roomRepo, userRepo)
+	ManageWsUsecase := roomWsUsecase.NewManageWsUsecase(roomRepo, userRepo, proposalRepo)
 	GetSrByRoomIDUsecase := roomUsecase.NewGetSrByRoomUsecase(roomRepo, settingRoomRepo)
 
 	roomHandler := r.NewRoomEchoHandler(


### PR DESCRIPTION
- Se arreglo un bug que no permitia actualizar los datos de una sala, era originado porque no se manejaba correctamente el campo state, lo que ocasionaba una lectura de puntero nulo


- Desestimar modificaciones en el modulo de websockets