### PR TITLE
Mejoras en reponses de rooms y manejo de errores

### DIFF
--- a/api/internal/rooms/application/useCases/websocket/socketStructs/Event.go
+++ b/api/internal/rooms/application/useCases/websocket/socketStructs/Event.go
@@ -34,6 +34,15 @@ type ErrorEvent struct{
 	Message string `json:"message"`
 }
 
+type ProposalEvent struct{
+	ID          uint    `json:"id"`
+	Archive     *string `json:"archive"`
+	Title       string  `json:"title"`
+	Description *string `json:"description"`
+	RoomID      uint    `json:"room_id"`
+}
+
+
 type FirstPropEvent struct {
 	Prop string `json:"prop"`
 }

--- a/api/internal/rooms/application/useCases/websocket/socketStructs/RoomLobby.go
+++ b/api/internal/rooms/application/useCases/websocket/socketStructs/RoomLobby.go
@@ -57,7 +57,7 @@ func StartVoting(event Event, c *Client) error {
 	log.Println("roger that")
 
 	for _, prop  := range c.Lobby().proposals {
-		log.Println(prop.Description().Description)
+		log.Println(prop)
 	}
 	
 	if c.user.ID().Id != c.Lobby().Admin().user.ID().Id {
@@ -72,16 +72,22 @@ func StartVoting(event Event, c *Client) error {
 	}
 
 	proposal := c.Lobby().proposals[0]
+	proposalevt := ProposalEvent{
+		ID: proposal.ID().Id,
+		Archive: &proposal.Archive().Archive,
+		Description: &proposal.Description().Description,
+		Title: proposal.Title().Title,
+	}
+
 	prop := Event{
 		Action: EventFirstProp,
-		Payload: marshalOrPanic(proposal),
+		Payload: marshalOrPanic(proposalevt),
 	}
 
 	for client := range c.Lobby().Clients() {
 		client.egress <- prop
 	}
 
-	log.Println("nice checkpoint")
 	return nil
 }
 

--- a/api/internal/rooms/application/useCases/websocket/socketStructs/RoomLobby.go
+++ b/api/internal/rooms/application/useCases/websocket/socketStructs/RoomLobby.go
@@ -71,21 +71,23 @@ func StartVoting(event Event, c *Client) error {
 		return nil
 	}
 
-	proposal := c.Lobby().proposals[0]
-	proposalevt := ProposalEvent{
-		ID: proposal.ID().Id,
-		Archive: &proposal.Archive().Archive,
-		Description: &proposal.Description().Description,
-		Title: proposal.Title().Title,
-	}
-
-	prop := Event{
-		Action: EventFirstProp,
-		Payload: marshalOrPanic(proposalevt),
-	}
-
-	for client := range c.Lobby().Clients() {
-		client.egress <- prop
+	if  len(c.Lobby().proposals) > 0 {
+		proposal := c.Lobby().proposals[0]
+		proposalevt := ProposalEvent{
+			ID: proposal.ID().Id,
+			Archive: &proposal.Archive().Archive,
+			Description: &proposal.Description().Description,
+			Title: proposal.Title().Title,
+		}
+	
+		prop := Event{
+			Action: EventFirstProp,
+			Payload: marshalOrPanic(proposalevt),
+		}
+	
+		for client := range c.Lobby().Clients() {
+			client.egress <- prop
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Ahora todos los endpoints que devuelvan informacion sobre la sala, van a contener un campo adicional "privileges" el cual es true o false segun si el usuario que haya solicitado esa informacion es administrador de la sala o no.
- Tambien se manejo un error en el cual se intenta iniciar la sala sin propuestas
- Se arreglo payload devuelto por la accion first_proposal